### PR TITLE
manifest: fix access to GVFS mounts

### DIFF
--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -20,13 +20,11 @@ cleanup:
 
 finish-args:
   - --share=network
-  - --share=ipc  # X11 needs this
+  - --share=ipc                       # X11 needs this
   - --socket=x11
   - --socket=wayland
   - --filesystem=host
-  # GVFS access not working yet, see:
-  # https://github.com/flathub/org.freefilesync.FreeFileSync/issues/14
-  - --filesystem=/run/user/$UID/gvfs  # access gvfs mounts
+  - --filesystem=xdg-run/gvfs         # access gvfs mounts
   - --talk-name=org.gtk.vfs.*         # access gvfs mounts
 
 modules:


### PR DESCRIPTION
It turns out that the required directory can be accessed using xdg-run
variable. See also:
https://github.com/flatpak/flatpak/issues/2900