### PR TITLE
appstream: revert translation and update_contact tags

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -73,6 +73,4 @@
     <content_attribute id="money-purchasing">mild</content_attribute>
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
-  ​<update_contact>zenju at freefilesync.org</update_contact>
-  <translation/>
 </component>


### PR DESCRIPTION
They should be non-mandatory again. For <translation> the empty tag is
controversial/non-compliant and for <update_contact> I'm not sure
whether it should be used this way (email of the program author, even if
they don't provide the appstream file).

See also: https://github.com/hughsie/appstream-glib/issues/302