### PR TITLE
change platform to FreeDesktop

### DIFF
--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -1,8 +1,8 @@
 app-id: org.freefilesync.FreeFileSync
 
-runtime: org.gnome.Platform
-runtime-version: '3.34'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '19.08'
+sdk: org.freedesktop.Sdk
 command: FreeFileSync
 
 build-options:


### PR DESCRIPTION
The GNOME platform is somewhat bigger than the FreeDesktop platform,
and we don't actually seem to use any part of it (FreeFileSync uses
GTK2). So let's switch to a leaner platform.