### PR TITLE
allow pulseaudio permission

### DIFF
--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -23,6 +23,7 @@ finish-args:
   - --share=ipc                       # X11 needs this
   - --socket=x11
   - --socket=wayland
+  - --socket=pulseaudio               # notification sounds
   - --filesystem=host
   - --filesystem=xdg-run/gvfs         # access gvfs mounts
   - --talk-name=org.gtk.vfs.*         # access gvfs mounts


### PR DESCRIPTION
FFS supports notification sounds, but they don't play without this
permission.

Fixes: https://github.com/flathub/org.freefilesync.FreeFileSync/issues/27