### PR TITLE
upstream release 10.21

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="10.21" date="2020-03-17"/>
     <release version="10.20" date="2020-02-14"/>
     <release version="10.19" date="2019-12-27"/>
     <release version="10.18" date="2019-11-19"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -49,8 +49,8 @@ modules:
         # the upstream is terrible, the original URL blocks curl/wget without
         # a specific user-agent, we need to use a mirror. Original URL example:
         # https://freefilesync.org/download/FreeFileSync_10.17_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_10.20_Linux.tar.gz
-        sha256: 2ef222eabbef34ff473c0d2eb21a5a6801cff96753eb4ac95d5b2fd2f0bb6cc8
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_10.21_Linux.tar.gz
+        sha256: 70a48f915933715e1e0893ec9ef8e8d431435f3274ecafb8050f043135bb3020
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop


### PR DESCRIPTION
I get an online check error on each startup:
![ffs](https://user-images.githubusercontent.com/755451/76945687-284a5580-6903-11ea-8ac4-13ff0762c0f2.png)
```
Error Code 336154918: error:14095126:SSL routines:ssl3_read_n:unexpected eof while reading [SSL_read_ex] SSL_ERROR_SSL
```

Since I made no changes outside of updating FFS, I assume it's a problem on their server. The same thing happens when I run the binary from their tarball directly, outside of Flatpak.