### PR TITLE
upstream release 10.23

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="10.23" date="2020-04-17"/>
     <release version="10.22" date="2020-03-18"/>
     <release version="10.21" date="2020-03-17"/>
     <release version="10.20" date="2020-02-14"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -31,6 +31,17 @@ finish-args:
 modules:
   - shared-modules/gtk2/gtk2.json
 
+    # without lsb_release, FFS shows an error at the end of each operation
+    # (in the log tab)
+  - name: lsb-release-compat
+    buildsystem: simple
+    build-commands:
+      - make install PREFIX=/app
+    sources:
+      - type: git
+        url: https://gitlab.com/nanonyme/lsb-release-compat.git
+        commit: 5751a93f4cd3885a9c3c92aa86026255851ad670
+
   - name: freefilesync
     buildsystem: simple
     build-commands:

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -1,8 +1,8 @@
 app-id: org.freefilesync.FreeFileSync
 
-runtime: org.freedesktop.Platform
-runtime-version: '19.08'
-sdk: org.freedesktop.Sdk
+runtime: org.gnome.Platform
+runtime-version: '3.36'
+sdk: org.gnome.Sdk
 command: FreeFileSync
 
 build-options:
@@ -49,8 +49,8 @@ modules:
         # the upstream is terrible, the original URL blocks curl/wget without
         # a specific user-agent, we need to use a mirror. Original URL example:
         # https://freefilesync.org/download/FreeFileSync_10.17_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_10.22_Linux.tar.gz
-        sha256: 74c02d76429396e208bbf148970ef5eefcfb063a3e6a92c17de4a637870d7554
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_10.23_Linux.tar.gz
+        sha256: fa4f8260097357a0307a31ecf78d93de6182255910852b1c101ed033a1de3c74
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop


### PR DESCRIPTION
Runtime was changed from freedesktop to gnome, because with freedesktop
all file icons were suddenly missing for some reason.