### PR TITLE
11.0

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="11.0" date="2020-07-21"/>
     <release version="10.25" date="2020-06-18"/>
     <release version="10.24" date="2020-05-17"/>
     <release version="10.23" date="2020-04-17"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -49,8 +49,8 @@ modules:
         # the upstream is terrible, the original URL blocks curl/wget without
         # a specific user-agent, we need to use a mirror. Original URL example:
         # https://freefilesync.org/download/FreeFileSync_10.17_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_10.25_Linux.tar.gz
-        sha256: 30615e761743321f344e17ff7d773ead7efb1ea018602d429dc1cba160046373
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.0_Linux.tar.gz
+        sha256: 14251e53e2c6338b76e6f69685ec491f134017156e34aa21515eb10be971d8ea
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -50,7 +50,7 @@ modules:
         # a specific user-agent, we need to use a mirror. Original URL example:
         # https://freefilesync.org/download/FreeFileSync_10.17_Linux.tar.gz
         url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.0_Linux.tar.gz
-        sha256: 14251e53e2c6338b76e6f69685ec491f134017156e34aa21515eb10be971d8e
+        sha256: 14251e53e2c6338b76e6f69685ec491f134017156e34aa21515eb10be971d8ea
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -50,7 +50,7 @@ modules:
         # a specific user-agent, we need to use a mirror. Original URL example:
         # https://freefilesync.org/download/FreeFileSync_10.17_Linux.tar.gz
         url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.0_Linux.tar.gz
-        sha256: 14251e53e2c6338b76e6f69685ec491f134017156e34aa21515eb10be971d8ea
+        sha256: 14251e53e2c6338b76e6f69685ec491f134017156e34aa21515eb10be971d8e
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop


### PR DESCRIPTION
Hi, I made some mistakes when commiting, thus three commits with message "upstream release 11.0". I hope that is not a problem.
Again - in `org.freefilesync.FreeFileSync.yml` file there is a URL that is not functional yet (you need to upload a binary into you fedorapeople drive).

What was tested:
- mirror sync between two internal hard drives inside my PC
- mirror sync between two USB drives
- mirror sync from my computer to Google Drive
- two-way sync between internal drives

All works fine, but bug #35 still exists. 