### PR TITLE
upstream release 11.1

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="11.1" date="2020-08-31"/>
     <release version="11.0" date="2020-07-21"/>
     <release version="10.25" date="2020-06-18"/>
     <release version="10.24" date="2020-05-17"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -49,8 +49,8 @@ modules:
         # the upstream is terrible, the original URL blocks curl/wget without
         # a specific user-agent, we need to use a mirror. Original URL example:
         # https://freefilesync.org/download/FreeFileSync_10.17_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.0_Linux.tar.gz
-        sha256: 14251e53e2c6338b76e6f69685ec491f134017156e34aa21515eb10be971d8ea
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.1_Linux.tar.gz
+        sha256: be6e7a2e7ecb4d96772d14facb8cfe3cd20cc18ce21be3d4244a549d3f3b0ed3
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop


### PR DESCRIPTION
I had a problem again, because when using CLI it shows me I don't have permission do `git push -u origin REL`. I had the same problem month ago. Now I just updated repo using only my Web Browser, because there wasn't much to do. I hope all is still acceptable.

What was tested:
1. mirror sync: internal PC harddrive → another internal PC drive
2. GDrive sync:
    1. simple mirror sync PC → GDrive
    2. simple two-way sync: PC ↔ GDrive
3. two-way sync within one drive

Looks fine.