### PR TITLE
upstream release 11.2

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="11.2" date="2020-10-02"/>
     <release version="11.1" date="2020-08-31"/>
     <release version="11.0" date="2020-07-21"/>
     <release version="10.25" date="2020-06-18"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -49,8 +49,8 @@ modules:
         # the upstream is terrible, the original URL blocks curl/wget without
         # a specific user-agent, we need to use a mirror. Original URL example:
         # https://freefilesync.org/download/FreeFileSync_10.17_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.1_Linux.tar.gz
-        sha256: be6e7a2e7ecb4d96772d14facb8cfe3cd20cc18ce21be3d4244a549d3f3b0ed3
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.2_Linux.tar.gz
+        sha256: 035070c8fd3228bafc1a333589793dc48bac3a4729d90da9ab29010deec56dc3
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop


### PR DESCRIPTION
### plz tell me you are able to merge it

***

What was tested:
1. mirror sync: internal PC harddrive → another internal PC drive
2. GDrive sync:
    1. simple mirror sync PC → GDrive
    2. simple two-way sync: PC ↔ GDrive (without previously existed databse)
3. two-way sync within one drive (without previously existed databse)

Seems to work fine, except problem #35, which still exists - I am pretty sure it is Flatpak issue, but I still can't debug Flatpak apps.