### PR TITLE
update GNOME runtime to 3.38

### DIFF
--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -1,7 +1,7 @@
 app-id: org.freefilesync.FreeFileSync
 
 runtime: org.gnome.Platform
-runtime-version: '3.36'
+runtime-version: '3.38'
 sdk: org.gnome.Sdk
 command: FreeFileSync
 


### PR DESCRIPTION
I wasn't sure what to test, so I made my "upstream release" tests:

1. mirror sync: internal PC harddrive → another internal PC drive
2. GDrive sync:
    1. simple mirror sync PC → GDrive
    2. simple two-way sync: PC ↔ GDrive (without previously existed databse)
3. two-way sync within one drive (without previously existed databse)
4. mirror sync to (and from) USB flash drive

I also made some minor manipulations with interface to check whether there are some kind of displaying issues.

_It works on my machine.™_ 