### PR TITLE
upstream release 11.3

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="11.3" date="2020-11-01"/>
     <release version="11.2" date="2020-10-02"/>
     <release version="11.1" date="2020-08-31"/>
     <release version="11.0" date="2020-07-21"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -49,8 +49,10 @@ modules:
         # the upstream is terrible, the original URL blocks curl/wget without
         # a specific user-agent, we need to use a mirror. Original URL example:
         # https://freefilesync.org/download/FreeFileSync_10.17_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.2_Linux.tar.gz
-        sha256: 035070c8fd3228bafc1a333589793dc48bac3a4729d90da9ab29010deec56dc3
+        # Currently used URL example:
+        #    https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.2_Linux.tar.gz
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.3_Linux.tar.gz
+        sha256: bae8d8c23c6e189b4c2dcd9626ac7a64e92c04f730aefd55fd5626c908cf481d
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop


### PR DESCRIPTION
1. mirror sync: internal PC harddrive → another internal PC drive
2. GDrive sync:
    1. simple mirror sync PC → GDrive
    2. simple two-way sync: PC ↔ GDrive (without previously existed databse)
3. two-way sync within one drive (without previously existed databse)
4. mirror sync to (and from) USB flash drive

seems to work fine if you use permanent file removing (so still the same as previous ones). 
When using moving files to Trash I now get an error (that a new thing and I am sure it is related with #35) and I don't know how to deal with that:
![Zrzut ekranu z 2020-11-04 18-40-40](https://user-images.githubusercontent.com/22769121/98151485-89de2500-1ed0-11eb-9b94-e34f249e1b03.png)

I also added currently used URL example into YML file, because it'd be helpful when testing (when tar isn't uploaded to your drive at the moment).