### PR TITLE
upstream release 11.4

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="11.4" date="2020-12-04"/>
     <release version="11.3" date="2020-11-01"/>
     <release version="11.2" date="2020-10-02"/>
     <release version="11.1" date="2020-08-31"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -51,8 +51,8 @@ modules:
         # https://freefilesync.org/download/FreeFileSync_11.3_Linux.tar.gz
         # A mirror URL example:
         # https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.3_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.3_Linux.tar.gz
-        sha256: bae8d8c23c6e189b4c2dcd9626ac7a64e92c04f730aefd55fd5626c908cf481d
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.4_Linux.tar.gz
+        sha256: 0a83bd28872f9139dc5bfe787f038c79502f170dcc4e8b4f69db5187c7b27132
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop


### PR DESCRIPTION
all seems to work fine, but you still need to use permanent removing.

I had a problem with SHA256, because my archive downloaded from official website had different checksum. I veryfied it and figured out that binary files in my archive (which is newer than that on your fedorapeople drive) are newer (from the next day - 5th December).
Unfortunately, the author doesn't provide checksums to verify it.
Eventually I used my archive with my checksums - but I am not sure which archive you should use.