### PR TITLE
upstream release 11.5

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="11.5" date="2021-01-02"/>
     <release version="11.4" date="2020-12-04"/>
     <release version="11.3" date="2020-11-01"/>
     <release version="11.2" date="2020-10-02"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -51,8 +51,8 @@ modules:
         # https://freefilesync.org/download/FreeFileSync_11.3_Linux.tar.gz
         # A mirror URL example:
         # https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.3_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.4_Linux.tar.gz
-        sha256: 0a83bd28872f9139dc5bfe787f038c79502f170dcc4e8b4f69db5187c7b27132
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.5_Linux.tar.gz
+        sha256: 6953ea298874e413b58a048e606e2d06ef66b7094eb772a5a1ebfd067acda6b2
         strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop


### PR DESCRIPTION
Tested:
1. mirror sync: internal PC harddrive → another internal PC drive 
2. GDrive sync:
    1. simple mirror sync PC → GDrive
    2. simple two-way sync: PC ↔ GDrive (without previously existed databse)
3. two-way sync within one drive (without previously existed databse)
4. mirror sync to (and from) USB flash drive

Works fine.
Problem #35 still exists.