### PR TITLE
use extra-data step to download FFS binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,33 @@ flatpak run --command=RealTimeSync org.freefilesync.FreeFileSync
 
 The workflow for building a new release `REL` is:
 ```
+# Create a new git branch REL (e.g. 11.6):
 git checkout -b REL master
-# adjust *FreeFileSync.yml and data/*appdata.xml
-flatpak-builder builddir org.freefilesync.FreeFileSync.yml --force-clean --ccache
-# test the app
-flatpak-builder --run builddir org.freefilesync.FreeFileSync.yml FreeFileSync
 
-git add -A
+# Adjust the manifest and appdata
+your-favorite-editor org.freefilesync.FreeFileSync.yml
+your-favorite-editor data/org.freefilesync.FreeFileSync.appdata.xml
+
+# Build and install. The installation part is necessary, because due to extra-data approach (see
+# manifest), the actual FFS binary is downloaded and processed only during installation.
+flatpak-builder builddir org.freefilesync.FreeFileSync.yml --force-clean --ccache --install --user
+
+# Test the app. Your dev version should be installed as the 'master' branch, so if you have the
+# stable version installed as well, you must distinguish them as shown below. Check your
+# 'flatpak list --app' output to make sure.
+flatpak run org.freefilesync.FreeFileSync//master
+
+# Remove the dev version of the app
+flatpak remove org.freefilesync.FreeFileSync//master
+
+# Commit the changes
+git add -u
+git diff --cached
 git commit
 git push -u origin REL
-# submit a PR
+# Submit the pull request now
 
-# after the PR is approved
+# After the PR is approved, release it
 git checkout master
 git merge --ff-only REL
 git push

--- a/data/apply_extra
+++ b/data/apply_extra
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+# An "apply_extra" script gets automatically executed after "extra-data" are downloaded
+# during installation. CWD is at /app/extra/.
+
+# The errexit is the reason why this script is not embeded directly in the app manifest
+set -o errexit -o pipefail
+
+# Uncomment this when debugging. Turns out the output is also shown to end-users when installing
+# on a command line, which looks somewhat unprofessional.
+#set -o verbose
+
+tar xf FFS.tar.gz
+test -d FreeFileSync
+rm FFS.tar.gz
+
+rm 'FreeFileSync/User Manual.pdf'
+
+# Check whether the target binary actually exists (test -f resolves symlinks)
+test -f /app/bin/FreeFileSync
+test -f /app/bin/RealTimeSync

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -34,10 +34,9 @@ modules:
   - name: freefilesync
     buildsystem: simple
     build-commands:
-      - rm -v 'FreeFileSync/User Manual.pdf'
-      - mv -v FreeFileSync/ /app/
-      - ln -sv "/app/FreeFileSync/Bin/FreeFileSync_$(uname -m)" /app/bin/FreeFileSync
-      - ln -sv "/app/FreeFileSync/Bin/RealTimeSync_$(uname -m)" /app/bin/RealTimeSync
+      - cp apply_extra /app/bin/
+      - ln -sv "/app/extra/FreeFileSync/Bin/FreeFileSync_$(uname -m)" /app/bin/FreeFileSync
+      - ln -sv "/app/extra/FreeFileSync/Bin/RealTimeSync_$(uname -m)" /app/bin/RealTimeSync
       - mkdir -pv /app/share/applications/
       - cp -v *.desktop /app/share/applications/
       - mkdir -pv /app/share/icons/hicolor/128x128/apps/
@@ -45,15 +44,6 @@ modules:
       - mkdir -pv /app/share/appdata
       - cp -v *.appdata.xml /app/share/appdata
     sources:
-      - type: archive
-        # the upstream is terrible, the original URL blocks curl/wget without
-        # a specific user-agent, we need to use a mirror. Original URL example:
-        # https://freefilesync.org/download/FreeFileSync_11.3_Linux.tar.gz
-        # A mirror URL example:
-        # https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.3_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.5_Linux.tar.gz
-        sha256: 6953ea298874e413b58a048e606e2d06ef66b7094eb772a5a1ebfd067acda6b2
-        strip-components: 0
       - type: file
         path: data/org.freefilesync.FreeFileSync.desktop
       - type: file
@@ -64,3 +54,25 @@ modules:
         path: data/org.freefilesync.FreeFileSync.RealTimeSync.png
       - type: file
         path: data/org.freefilesync.FreeFileSync.appdata.xml
+      # We don't compile FFS sources, because they are often broken and depend on modified system
+      # libraries. Instead, we use pre-compiled binaries. However, the binary licence disallows
+      # changes to the archive during distribution, and so we need to download the binary and
+      # process it on the client during installation. For more information, see:
+      # https://github.com/flathub/org.freefilesync.FreeFileSync/issues/48
+      - type: extra-data
+        # this ends up stored in /app/extra/
+        filename: FFS.tar.gz
+        # The upstream is terrible, the original URL blocks curl/wget without
+        # a specific user-agent, we need to use a mirror. Original URL example:
+        # https://freefilesync.org/download/FreeFileSync_11.3_Linux.tar.gz
+        # A mirror URL example:
+        # https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.3_Linux.tar.gz
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.5_Linux.tar.gz
+        sha256: 6953ea298874e413b58a048e606e2d06ef66b7094eb772a5a1ebfd067acda6b2
+        size: 25724806
+        # just a rough size (extracted), we don't want to update it with each release
+        installed-size: 30000000  # 30 MB
+      # An "apply_extra" script gets automatically executed after "extra-data" are downloaded
+      # during installation. CWD is at /app/extra/.
+      - type: file
+        path: data/apply_extra


### PR DESCRIPTION
The binary license doesn't permit redistribution if the original archive is
adjusted. Instead, download it as the extra-data step, i.e. during installation
on the user's machine. This doesn't violate its license.

Fixes: https://github.com/flathub/org.freefilesync.FreeFileSync/issues/48