### PR TITLE
upstream release 11.6

### DIFF
--- a/data/apply_extra
+++ b/data/apply_extra
@@ -1,16 +1,25 @@
 #!/usr/bin/bash
-# An "apply_extra" script gets automatically executed after "extra-data" are downloaded
-# during installation. CWD is at /app/extra/.
+# An "apply_extra" script gets automatically executed after "extra-data" are downloaded during
+# installation. CWD is at /app/extra/.
 
 # The errexit is the reason why this script is not embeded directly in the app manifest
 set -o errexit -o pipefail
 
-# Uncomment this when debugging. Turns out the output is also shown to end-users when installing
-# on a command line, which looks somewhat unprofessional.
+# Uncomment this when debugging, comment out for a final release. The output would otherwise be
+# also shown to end-users when installing on a command line, which would look bad.
 #set -o verbose
+#set -o xtrace
 
 tar xf FFS.tar.gz
-test -d FreeFileSync
+test "$(ls -1 FreeFileSync*.run | wc -l)" -eq 1
+mv FreeFileSync*.run FreeFileSync_Install.run
+7z x -oFFS_Installer_Archive FreeFileSync_Install.run >/dev/null
+test -d FFS_Installer_Archive
+mkdir FreeFileSync
+tar xf FFS_Installer_Archive/FreeFileSync.tar.gz --directory FreeFileSync
+
+rm -rf FFS_Installer_Archive
+rm FreeFileSync_Install.run
 rm FFS.tar.gz
 
 rm 'FreeFileSync/User Manual.pdf'

--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="11.6" date="2021-02-01"/>
     <release version="11.5" date="2021-01-02"/>
     <release version="11.4" date="2020-12-04"/>
     <release version="11.3" date="2020-11-01"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -15,6 +15,7 @@ cleanup:
   - /lib/debug
   - /lib/pkgconfig
   - /share/doc
+  - /share/man
   - '*.la'
   - '*.a'
 
@@ -30,6 +31,19 @@ finish-args:
 
 modules:
   - shared-modules/gtk2/gtk2.json
+
+  - name: p7zip
+    no-autogen: true
+    make-args:
+      - 7z
+    sources:
+      - type: git
+        url: https://github.com/jinfeihan57/p7zip.git
+        tag: v17.03
+        commit: be1a54f3f7b19221fc6b48855c971b4386e34edf
+      - type: shell
+        commands:
+          - sed -i 's|/usr/local|/app|g' makefile.common
 
   - name: freefilesync
     buildsystem: simple
@@ -67,9 +81,9 @@ modules:
         # https://freefilesync.org/download/FreeFileSync_11.3_Linux.tar.gz
         # A mirror URL example:
         # https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.3_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.5_Linux.tar.gz
-        sha256: 6953ea298874e413b58a048e606e2d06ef66b7094eb772a5a1ebfd067acda6b2
-        size: 25724806
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.6_Linux.tar.gz
+        sha256: f8a0edb87dd3f6c3cbeb491c5dc6a121a162c207c3d4298fa3856ae3b331d7a0
+        size: 26015496
         # just a rough size (extracted), we don't want to update it with each release
         installed-size: 30000000  # 30 MB
       # An "apply_extra" script gets automatically executed after "extra-data" are downloaded


### PR DESCRIPTION
This introduces a p7zip module dependency, so that we can extract the new
installer used for the project.

Fixes: https://github.com/flathub/org.freefilesync.FreeFileSync/issues/46