### PR TITLE
upstream release 11.11

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -44,6 +44,7 @@
     <binary>RealTimeSync</binary>
   </provides>
   <releases>
+    <release version="11.11" date="2021-06-11"/>
     <release version="11.10" date="2021-05-09"/>
     <release version="11.9" date="2021-04-01"/>
     <release version="11.6" date="2021-02-01"/>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -43,8 +43,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/jinfeihan57/p7zip.git
-        tag: v17.03
-        commit: be1a54f3f7b19221fc6b48855c971b4386e34edf
+        tag: v17.04
+        commit: 0b5b1b1a866d0e41cb7945e60a32262874e724aa
       - type: shell
         commands:
           - sed -i 's|/usr/local|/app|g' makefile.common
@@ -85,9 +85,9 @@ modules:
         # https://freefilesync.org/download/FreeFileSync_11.3_Linux.tar.gz
         # A mirror URL example:
         # https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.3_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.10_Linux.tar.gz
-        sha256: 1c6549856afb4a1334a44f42860f804c803f14d99e0e500a8ba34b14a68085cd
-        size: 26429739
+        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.11_Linux.tar.gz
+        sha256: c8582134fa9f7e3ad94bdde3fdf14b5078d9ab5e5132dfc8913dc4ee6c44f00b
+        size: 26434985
         # just a rough size (extracted), we don't want to update it with each release
         installed-size: 30000000  # 30 MB
       # An "apply_extra" script gets automatically executed after "extra-data" are downloaded


### PR DESCRIPTION
Also update shared-modules and p7zip.

Fixes: https://github.com/flathub/org.freefilesync.FreeFileSync/issues/59
Closes: https://github.com/flathub/org.freefilesync.FreeFileSync/pull/60