### PR TITLE
appdata: add a note about running external apps

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -14,11 +14,19 @@
       amount of data needed.
     </p>
     <p>
-      NOTE: Due to technical limitations, FreeFileSync installed from
-      a Flatpak can't read configuration files of your other Flatpak
-      applications, commonly stored at ~/.var/app/. If you need to
-      process files in that directory, you must use a non-Flatpak installation
-      of FreeFileSync (or some other tool).
+      NOTE: Due to technical limitations, FreeFileSync installed from a Flatpak
+      can't read configuration files of your other Flatpak applications,
+      commonly stored at "~/.var/app/". If you need to process files in that
+      directory, you must use a non-Flatpak installation of FreeFileSync (or
+      some other tool).
+    </p>
+    <p>
+      NOTE 2: FreeFileSync allows you to open files in external applications or
+      run custom scripts. However, when sandboxed as Flatpak, external
+      applications or scripts from your host system are not accessible. However,
+      you can use the Flatseal app to grant FreeFileSync a permission to access
+      "D-Bus session bus", and then it should be possible to run run your app or
+      script if you prefix your command with "flatpak-spawn --host".
     </p>
   </description>
   <url type="homepage">https://freefilesync.org</url>


### PR DESCRIPTION
Document the basics of how to run external commands. Also add some formatting that had to be removed before (in b19e7481).

Fixes: https://github.com/flathub/org.freefilesync.FreeFileSync/issues/80