### PR TITLE
merge beta to master

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -64,6 +64,26 @@
     <display_length side="longest" compare="ge">1200</display_length>
   </recommends>
   <releases>
+    <release version="12.0" date="2023-01-21">
+      <description>
+        <ul>
+            <li>Don't save password and show prompt instead for (S)FTP</li>
+            <li>Fast path check failure on access errors</li>
+            <li>Support PuTTY private key file version 3</li>
+            <li>Respect timeout during SFTP connect</li>
+            <li>Removed 20-sec timeout while checking directory existence</li>
+            <li>Avoid hitting (S)FTP connection limit for non-uniform configs</li>
+            <li>Fixed middle grid tooltip icon not always showing (Linux)</li>
+            <li>Optimized file accesses when checking file path existence</li>
+            <li>Fixed overview navigation marker not always showing on main grid</li>
+            <li>Clear all grid selections after view filter toggle</li>
+            <li>Fixed mouse selection starting on folder group</li>
+            <li>Don't require sudo during non-root installation (Linux)</li>
+            <li>Stricter type checking when deleting file/folder/symlinks</li>
+            <li>Succinct error messages when path component is not existing</li>
+        </ul>
+      </description>
+    </release>
     <release version="11.29" date="2022-12-16">
       <description>
         <ul>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -77,7 +77,9 @@ modules:
       - type: extra-data
         # this ends up stored in /app/extra/
         filename: FFS.tar.gz
-        url: https://freefilesync.org/download/FreeFileSync_12.0_Linux.tar.gz
+        # The upstream server randomly fails to serve the archive (see #97 and #98), we need to use
+        # a mirror.
+        url: https://github.com/flathub/org.freefilesync.FreeFileSync/releases/download/reupload-12.0/FreeFileSync_12.0_Linux.tar.gz
         sha256: 90630cc8c77d39af8e7746ce664738f9590ea7586454c90a66ad09248c41eb4f
         size: 30809464
         # just a rough size (extracted), we don't want to update it with each release

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -39,7 +39,7 @@ modules:
       - 7z
     sources:
       - type: git
-        url: https://github.com/jinfeihan57/p7zip.git
+        url: https://github.com/p7zip-project/p7zip
         tag: v17.04
         commit: 0b5b1b1a866d0e41cb7945e60a32262874e724aa
       - type: shell
@@ -77,14 +77,9 @@ modules:
       - type: extra-data
         # this ends up stored in /app/extra/
         filename: FFS.tar.gz
-        # The upstream is terrible, the original URL blocks curl/wget without
-        # a specific user-agent, we need to use a mirror. Original URL example:
-        # https://freefilesync.org/download/FreeFileSync_11.3_Linux.tar.gz
-        # A mirror URL example:
-        # https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.3_Linux.tar.gz
-        url: https://kparal.fedorapeople.org/mirror/freefilesync/FreeFileSync_11.29_Linux.tar.gz
-        sha256: 1c89cae32098c06262d88a9ab57bdea2703bd5a090668bdde1686c4ff1009d18
-        size: 30702961
+        url: https://freefilesync.org/download/FreeFileSync_12.0_Linux.tar.gz
+        sha256: 90630cc8c77d39af8e7746ce664738f9590ea7586454c90a66ad09248c41eb4f
+        size: 30809464
         # just a rough size (extracted), we don't want to update it with each release
         installed-size: 40000000  # 40 MB
       # An "apply_extra" script gets automatically executed after "extra-data" are downloaded


### PR DESCRIPTION
This also switches the tarball source URL back to FFS upstream, instead of a private mirror. It seems that (hopefully) the upstream now works OK with curl downloads, and also Ubuntu-based distros had SSL errors with fedorapeople.org for some reason (#96).

Another change is that p7zip github project was renamed, accommodate.

Related: https://github.com/flathub/org.freefilesync.FreeFileSync/issues/96