### PR TITLE
upstream release 12.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -64,6 +64,24 @@
     <display_length side="longest" compare="ge">1200</display_length>
   </recommends>
   <releases>
+    <release version="12.1" date="2023-02-20">
+      <description>
+        <ul>
+            <li>First official build based on GTK3 (Linux)</li>
+            <li>Allow cancel during folder path normalization (e.g. delay during HDD spin up)</li>
+            <li>Fixed slow FTP comparison performance due to libcurl regression</li>
+            <li>Open terminal with log messages on startup error (Linux)</li>
+            <li>Preserve changed config during auto-update</li>
+            <li>Save config during unexpected reboot (Linux)</li>
+            <li>Preserve config upon SIGTERM (Linux, macOS)</li>
+            <li>Fixed progress dialog z-order after switching windows (macOS)</li>
+            <li>Removed packet size limit for SFTP directory reading</li>
+            <li>Mouse hover effects for config and overview grid</li>
+            <li>Always update existing shortcuts during installation (Windows, Linux)</li>
+            <li>Fixed another "Some files will be synchronized as part of multiple base folders" false-negative</li>
+        </ul>
+      </description>
+    </release>
     <release version="12.0" date="2023-01-21">
       <description>
         <ul>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -13,6 +13,7 @@ cleanup:
   - /include
   - /lib/cmake
   - /lib/pkgconfig
+  - /man
   - /share/doc
   - /share/man
   - '*.la'
@@ -20,8 +21,9 @@ cleanup:
 
 finish-args:
   - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=ipc                       # X11 needs this
-  - --socket=x11
   - --socket=pulseaudio               # notification sounds
   - --filesystem=host
   # access gvfs mounts
@@ -31,8 +33,6 @@ finish-args:
   - --talk-name=org.gtk.vfs.*
 
 modules:
-  - shared-modules/gtk2/gtk2.json
-
   - name: p7zip
     no-autogen: true
     make-args:
@@ -40,8 +40,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/p7zip-project/p7zip
-        tag: v17.04
-        commit: 0b5b1b1a866d0e41cb7945e60a32262874e724aa
+        tag: v17.05
+        commit: d5fa760eee206064ad037b177e1182eb86841094
       - type: shell
         commands:
           - sed -i 's|/usr/local|/app|g' makefile.common
@@ -79,9 +79,9 @@ modules:
         filename: FFS.tar.gz
         # The upstream server randomly fails to serve the archive (see #97 and #98), we need to use
         # a mirror.
-        url: https://github.com/flathub/org.freefilesync.FreeFileSync/releases/download/reupload-12.0/FreeFileSync_12.0_Linux.tar.gz
-        sha256: 90630cc8c77d39af8e7746ce664738f9590ea7586454c90a66ad09248c41eb4f
-        size: 30809464
+        url: https://github.com/flathub/org.freefilesync.FreeFileSync/releases/download/reupload-12.1/FreeFileSync_12.1_Linux.tar.gz
+        sha256: 8a19e3f32c62fba8fd023be36f1cd75d95315a623ac543da1b973f6ef1c96efc
+        size: 30893781
         # just a rough size (extracted), we don't want to update it with each release
         installed-size: 40000000  # 40 MB
       # An "apply_extra" script gets automatically executed after "extra-data" are downloaded


### PR DESCRIPTION
FFS finally switched to GTK3, and so we can drop building of GTK2.