### PR TITLE
allow access to ~/.var/app

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -14,14 +14,7 @@
       amount of data needed.
     </p>
     <p>
-      NOTE: Due to technical limitations, FreeFileSync installed from a Flatpak
-      can't read configuration files of your other Flatpak applications,
-      commonly stored at "~/.var/app/". If you need to process files in that
-      directory, you must use a non-Flatpak installation of FreeFileSync (or
-      some other tool).
-    </p>
-    <p>
-      NOTE 2: FreeFileSync allows you to open files in external applications or
+      NOTE: FreeFileSync allows you to open files in external applications or
       run custom scripts. However, when sandboxed as Flatpak, external
       applications or scripts from your host system are not accessible. However,
       you can use the Flatseal app to grant FreeFileSync a permission to access

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -30,6 +30,9 @@ finish-args:
   - --filesystem=xdg-run/gvfs
   - --filesystem=xdg-run/gvfsd
   - --talk-name=org.gtk.vfs.*
+  # access ~/.var/app for backup purposes
+  # https://github.com/flathub/org.freefilesync.FreeFileSync/issues/47
+  - --filesystem=~/.var/app
 
 modules:
   - shared-modules/gtk2/gtk2.json


### PR DESCRIPTION
This is needed for people wanting to back up the data of their Flatpak apps. It seems the access would be possible through file-open dialog portal, if FFS used a recent enough GUI toolkit. But for the moment, it needs to be hardcoded.

Fixes https://github.com/flathub/org.freefilesync.FreeFileSync/issues/47