### PR TITLE
use markup in app description

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -14,12 +14,12 @@
       amount of data needed.
     </p>
     <p>
-      NOTE: FreeFileSync allows you to open files in external applications or
+      <em>NOTE:</em> FreeFileSync allows you to open files in external applications or
       run custom scripts. However, when sandboxed as Flatpak, external
       applications or scripts from your host system are not accessible. However,
       you can use the Flatseal app to grant FreeFileSync a permission to access
-      "D-Bus session bus", and then it should be possible to run run your app or
-      script if you prefix your command with "flatpak-spawn --host".
+      <em>"D-Bus session bus"</em>, and then it should be possible to run run your app or
+      script if you prefix your command with <code>flatpak-spawn --host</code>.
     </p>
   </description>
   <url type="homepage">https://freefilesync.org</url>


### PR DESCRIPTION
Flatpak has finally moved to libappstream, it seems.

Fixes: https://github.com/flathub/org.freefilesync.FreeFileSync/issues/87