### PR TITLE
upstream release 13.7

### DIFF
--- a/data/org.freefilesync.FreeFileSync.appdata.xml
+++ b/data/org.freefilesync.FreeFileSync.appdata.xml
@@ -52,6 +52,16 @@ Now you can run any app/command, if you prefix it with "<code>flatpak-spawn --ho
     <display_length side="longest" compare="ge">1200</display_length>
   </recommends>
   <releases>
+    <release version="13.7" date="2024-06-23">
+      <description>
+        <ul>
+          <li>Support copying symlinks between SFTP devices</li>
+          <li>Fixed input focus not being restored after comparison/sync</li>
+          <li>Fixed log file pruning not considering selected configuration</li>
+          <li>Show startup error details when running outside terminal (Linux)</li>
+        </ul>
+      </description>
+    </release>
     <release version="13.6" date="2024-05-10">
       <description>
         <ul>

--- a/org.freefilesync.FreeFileSync.yml
+++ b/org.freefilesync.FreeFileSync.yml
@@ -1,7 +1,7 @@
 app-id: org.freefilesync.FreeFileSync
 
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: FreeFileSync
 
@@ -83,9 +83,9 @@ modules:
         filename: FFS.tar.gz
         # The upstream server randomly fails to serve the archive (see #97 and #98), we need to use
         # a mirror.
-        url: https://github.com/flathub/org.freefilesync.FreeFileSync/releases/download/reupload-13.6/FreeFileSync_13.6_Linux.tar.gz
-        sha256: 6284e3eed44f371fdb6c9649a23649313eee86a293b40f5a927c77d2d6db9b06
-        size: 32509627
+        url: https://github.com/flathub/org.freefilesync.FreeFileSync/releases/download/reupload-13.7/FreeFileSync_13.7_Linux.tar.gz
+        sha256: 13b6443f4e1f03bc7c37fe9d260435886ad80ee292c0a3b5b9cdeb763576e31b
+        size: 32529382
         # just a rough size (extracted), we don't want to update it with each release
         installed-size: 40000000  # 40 MB
       # An "apply_extra" script gets automatically executed after "extra-data" are downloaded


### PR DESCRIPTION
Bump GNOME platform to version 46.